### PR TITLE
Remove unused blog features

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,6 @@
-remote_theme: "mmistakes/minimal-mistakes@4.16.4"
+remote_theme: "mmistakes/minimal-mistakes@4.24.0"
+atom_feed:
+  hide: true
 
 title: "Reconciliation census"
 name: "W3C Entity Reconciliation Community Group"

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,5 @@
+---
+layout: archive
+---
+
+{{ content }}


### PR DESCRIPTION
As discussed in our February meeting:
https://etherpad.lobid.org/p/reconciliation-february-2022

- Update theme version to support hiding the feed icon
- Set up custom home layout to remove "Recent Posts"

See:

https://mmistakes.github.io/minimal-mistakes/docs/configuration/#disable-feed-icons
https://mmistakes.github.io/minimal-mistakes/docs/overriding-theme-defaults/
https://github.com/mmistakes/minimal-mistakes/blob/master/_layouts/home.html