### PR TITLE
Add TEI publisher

### DIFF
--- a/_pages/clients.md
+++ b/_pages/clients.md
@@ -13,5 +13,6 @@ services using the reconciliation API.
 * [reconciler](https://github.com/jvfe/reconciler)
 * [SemTUI](https://arxiv.org/abs/2203.09521)
 * [Testbench](https://reconciliation-api.github.io/testbench/)
+* [TEI Publisher](https://teipublisher.com)
 * Any other?
 


### PR DESCRIPTION
See the documentation on GitHub which has not yet been deployed as HTML doc (will be added with the next release):
https://github.com/eeditiones/tei-publisher-app/blob/bdffd983b84297f296145e16687a59841aef5161/data/doc/documentation.xml#L8551-L8568

Thanks, @awagner-mainz, for calling my attention to this TEI publisher feature which was added in November 2021.