### PR TITLE
Add py-reconciliation-service-api

### DIFF
--- a/_pages/clients.md
+++ b/_pages/clients.md
@@ -15,5 +15,6 @@ services using the reconciliation API.
 * [SemTUI](https://arxiv.org/abs/2203.09521)
 * [Testbench](https://reconciliation-api.github.io/testbench/)
 * [TEI Publisher](https://teipublisher.com)
+* [py-reconciliation-service-api](https://github.com/derenrich/py-reconciliation-service-api) (Python library)
 * Any other?
 


### PR DESCRIPTION
I'd add this in this section (Clients) because it does not look like it can be used to run reconciliation services itself (otherwise I'd add it to the "Libraries" section)